### PR TITLE
Allows all 360 angles to be selected

### DIFF
--- a/src/components/RotspriteTool/RotspriteTool.tsx
+++ b/src/components/RotspriteTool/RotspriteTool.tsx
@@ -98,6 +98,7 @@ export const RotspriteTool = ({
               type="range"
               min="0"
               max="360"
+              step="1"
             />
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,7 @@ input[type='range'] {
   border: 1px solid #d1cfcf;
   border-radius: 5px;
   height: 6px;
+  width: 360px;
 }
 
 input[type='range']::-webkit-slider-thumb {


### PR DESCRIPTION
Currently the range inputs have no defined width. By default they are narrower than 360px so the user can only select (roughly) every 1-in-2 angles. For example, it's not possible to select 45 degrees.

This change adds the following to the input range elements:
1. `step="1"` attribute in HTML
2. `width: 360px;` in CSS

These changes allow all 360 angles to be selected.